### PR TITLE
Alphabetical Ordering with pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,18 +55,18 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - Ashwin Kachhara http://ashwinkachhara.com
 - Athul Atom Vayalinkal http://vayalinkal.com
 - Austin L. Chang http://www.austinlchang.com
-- Bilal Majeed http://bilalmajeed.com
 - Ben Stobaugh http://helloben.co
 - Ben Weinstein-Raun http://www.benwr.net
 - Ben Williams http://719Ben.com
 - Berwin Xie http://berwin.io
+- Bilal Majeed http://bilalmajeed.com
 - Brandon Amos http://bamos.github.io
 - Brandon Davis http://redspin.net
 - Brandon Truong http://hello.brandontruong.com
 - Brendan Ryan http://brendanjryan.com/
 - Brent Bovenzi http://bbovenzi.com/
-- Brian Chuk http://devchuk.github.io/
 - Brian Chu www.brianchu.com
+- Brian Chuk http://devchuk.github.io/
 - Brijesh Patel https://about.me/brijeshpatel9
 - Britt Mathis http://bmuk.io
 - Bruno B. Ferrari Faviero http://brunofaviero.com
@@ -111,8 +111,8 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - Diana Zink http://doerhub.com/of/diana
 - Dima Konev http://ezhik.me
 - Dylan McIntyre http://dmcintyre.net
-- Elissa Shevinsky http://elissashevinsky.com
 - Eli White http://eli-white.com
+- Elissa Shevinsky http://elissashevinsky.com
 - Emily Tran http://emilytran.org
 - Eric Song http://ericsong.io
 - Eric Zinnikas https://ericz.com
@@ -161,14 +161,14 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - Jay Mo http://jaymo.me/
 - Jaylen Wimbish http://www.jaylenwimbish.com/
 - Jeffrey Lin http://linjeffrey.me
-- Jevin Sidhu http://jevinsidhu.com
 - Jennifer Apacible http://apacible.us/
 - Jeremy Meyer http://jeremymeyer.us
 - Jerica Huang http://jericahuang.com
 - Jerrick Davis http://jerrick.us
-- Jesse Collins http://jtcollins.me
 - Jesse Chand http://jessechand.com
+- Jesse Collins http://jtcollins.me
 - Jessica Chang http://jessmchang.com
+- Jevin Sidhu http://jevinsidhu.com
 - Jian Wei Chuah http://jianweichuah.com
 - Jing Xiao http://www.notajingoist.com/index.html
 - Joe Duncko http://joeduncko.com/
@@ -210,18 +210,18 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - Laurence Welch http://laurencewelch.com
 - Lawrence Lin Murata http://lawrencemurata.com/
 - Lex Alexander http://coderlex.com
+- Li Xuanji http://xuanji.li
 - Liam Horne http://lihorne.com
 - Liang Gao http://liang.gao.nyc
-- Li Xuanji http://xuanji.li
 - Long Tran http://ltran.co
 - Luka Marr http://lukamarr.github.io
 - Mahir Kothary http://mahirk.com
 - Manoj Pandey http://manojp.co
 - Marco Bettiolo http://bettiolo.it
 - Maria Chavez http://mariachavez.co
-- Markan Patel http://markanpatel.me
 - Mark Diez http://markediez.com/
 - Mark Ormesher https://www.markormesher.co.uk/
+- Markan Patel http://markanpatel.me
 - Martin Petkov http://www.martinpetkov.me/
 - Masoud Harati https://masoudh.ml
 - Matheus C. Candido http://cassiano.me
@@ -282,7 +282,6 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - Roger Zou http://rogergzou.com
 - Rohan Likhite http://rohanlikhite.com
 - Rohan Yelsangikar http://royels.me
-- Rõhith Varanasi http://rohithvaranasi.com
 - Ruiqi Mao http://www.ruiqimao.com/
 - Rushi Shah http://www.rshah.io/
 - Rushy Panchal https://panchr.me
@@ -291,8 +290,9 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - Ryan Lin http://ryanlin.com
 - Ryan Senanayake http://www.RSenApps.com
 - Ryhan Hassan http://ryhan.org
-- Sahibjot Saggu http://www.sahibjot.me/
+- Rõhith Varanasi http://rohithvaranasi.com
 - Sagar Garg http://sagargarg.github.io/
+- Sahibjot Saggu http://www.sahibjot.me/
 - Sai Grandhi http://grandhi.me
 - Saleh Hamadeh http://shamadeh.com
 - Saleh Kaddoura http://tekee.herokuapp.com/
@@ -317,8 +317,8 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - Stephen Greco https://sgre.co/
 - Steve Dean http://about.me/stevenmdean
 - Steven Bock http://stevenbock.me
-- Sudarshan Muralidhar http://smuralidhar.com
 - Su Min Kim http://suminkim.me/
+- Sudarshan Muralidhar http://smuralidhar.com
 - Suril Shah http://www.eng.uwaterloo.ca/~sn3shah/
 - Taher Dhilawala http://taher.me
 - Tejas Manohar http://tejas.io
@@ -342,8 +342,8 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - Vishnu Narang http://vishnun.github.io
 - Vishnu Ravi http://vishnu.io/
 - Wasim Thabraze http://thabraze.in
-- William Cockburn http://syrexide.com
 - Will Field-Thompson http://willft.io
+- William Cockburn http://syrexide.com
 - William Huang http://www.hellowilliam.com
 - William Woodruff http://woodruffw.us
 - Yask Srivastava http://iyask.me

--- a/deploy_hooks.sh
+++ b/deploy_hooks.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd .git/hooks
+cp --symbolic-link ../../hooks/* .

--- a/github.md
+++ b/github.md
@@ -195,8 +195,8 @@ Hackathon Hackers' GitHub profiles
 - Dhiraj Bodicherla https://github.com/dhirajbodicherla
 - Dhruv Arora https://github.com/dhruvarora
 - Diana Zink https://github.com/deftworker
-- Dima Konev https://github.com/silverezhik
 - Dilpreet Chana https://github.com/DSchana
+- Dima Konev https://github.com/silverezhik
 - Douglas Bumby https://github.com/istx25
 - Drbyo Mkwi https://github.com/Dirbaio
 - Dvid Silva https://github.com/dvidsilva
@@ -218,8 +218,8 @@ Hackathon Hackers' GitHub profiles
 - Ethan Arnold https://github.com/masonsbro
 - Ethan Richardson http://github.com/ethanx94
 - Eugene Cheung https://github.com/arkon
-- Faisal Aldilaijan https://github.com/aldilaff
 - Faiq Raza https://github.com/faiq
+- Faisal Aldilaijan https://github.com/aldilaff
 - Faiz Ahmad https://github.com/Faiz7412
 - Faiz Ahmed Khan https://github.com/dridon
 - Fan Zhang https://github.com/fanwashere
@@ -313,8 +313,8 @@ Hackathon Hackers' GitHub profiles
 - Jaxon Stevens https://github.com/LemonaInc
 - Jay Kamat https://github.com/jgkamat
 - Jay Mo https://github.com/jayhxmo
-- Jaylen Wimbish https://github.com/jaylenw
 - Jay Zalowitz https://github.com/jayzalowitz
+- Jaylen Wimbish https://github.com/jaylenw
 - Jeffrey Lin https://github.com/linjeffrey
 - Jennifer Apacible https://github.com/japacible
 - Jeremy Meyer https://github.com/jjman505
@@ -358,7 +358,6 @@ Hackathon Hackers' GitHub profiles
 - Joyce Yan https://github.com/joyceyan
 - Juan Chomali https://github.com/jchomali
 - Julien L https://github.com/26medias
-- 서태웅 (Justice Suh) https://github.com/justicesuh
 - Justin Bleuel http://www.columbia.edu/~jmb2372/
 - Justin Cano https://github.com/bumrush
 - Justin Chan https://github.com/justinthec
@@ -426,12 +425,12 @@ Hackathon Hackers' GitHub profiles
 - Mahir Kothary https://github.com/mahirk
 - Manash Mandal https://github.com/manashmndl
 - Marco Bettiolo https://github.com/bettiolo
-- María Teresa Chávez https://github.com/materechm
 - Marius Sebastian Trif https://github.com/coolsebz
 - Mark Ormesher https://github.com/markormesher
 - Markan Patel https://github.com/cooltoast
-- Martin Petkov https://github.com/MartinPetkov
 - Marouane Nafaa https://github.com/mnafaa
+- Martin Petkov https://github.com/MartinPetkov
+- María Teresa Chávez https://github.com/materechm
 - Masoud Harati https://github.com/MasoudH
 - Matan Uchen https://github.com/matan157
 - Matheus C. Candido https://github.com/mcassiano
@@ -471,8 +470,8 @@ Hackathon Hackers' GitHub profiles
 - Milan Dasgupta https://github.com/milanocookies93
 - Milind Shah https://github.com/promilo
 - Milstein Munakami https://github.com/Milstein
-- Minh Nguyen https://github.com/minhongrails
 - Ming Luo https://github.com/Mingling94
+- Minh Nguyen https://github.com/minhongrails
 - Miquel Llobet https://github.com/mllobet
 - Moez Bhatti https://github.com/moezbhatti
 - Moksh Jawa https://github.com/mokshjawa
@@ -583,7 +582,6 @@ Hackathon Hackers' GitHub profiles
 - Rohan Shah https://github.com/rohan4
 - Rohan Shah https://github.com/Rohanyshah
 - Rohan Yelsangikar https://github.com/royels
-- Rõhith Varanasi https://github.com/Rohfosho
 - Ron Bhatta https://github.com/aranibatta
 - Ronak Patel https://github.com/ronakp
 - Ross Semenov https://github.com/rossem
@@ -598,6 +596,7 @@ Hackathon Hackers' GitHub profiles
 - Ryan Lin https://github.com/ryansl
 - Ryan Senanayake https://github.com/RSenApps
 - Ryhan Hassan https://github.com/ryhan
+- Rõhith Varanasi https://github.com/Rohfosho
 - Sachan Ganesh https://github.com/sachanganesh
 - Sacheth Chandramouli https://github.com/Sapchan
 - Sagar Garg https://github.com/sagargarg
@@ -734,3 +733,4 @@ Hackathon Hackers' GitHub profiles
 - Zakariyya Mughal https://github.com/zmughal
 - Zane Blackwell Sterling https://github.com/Shriken
 - Zhou Yi https://github.com/ZhouYii
+- 서태웅 (Justice Suh) https://github.com/justicesuh

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import os
+import sys
+
+def extract_names(f_name):
+    with open(f_name, 'r') as f:
+        for line in f:
+            # Probably should look for -\S+[A-Za-z\S]+ <url> instead
+            if line.startswith('- '):
+                yield line.split(' ', 1)[1]
+
+def strip_url(s):
+    return " ".join(s.strip().split(' ')[:-1])
+
+def validate_ordering():
+    ret_val = 0
+    for f_name in ['README.md', 'github.md']:
+        if not os.path.exists(f_name):
+            print(' [-] Aborting commit: expecting %s to exist'%f_name)
+            ret_val = 1
+        else:
+            print(' [+] Checking %s'%f_name)
+            prev_line = None
+            for line in extract_names(f_name):
+                if prev_line is not None and line.lower() < prev_line.lower():
+                    print(" [-] Aborting commit: %s and %s are out of order!"%(
+                        strip_url(line),
+                        strip_url(prev_line)))
+                    ret_val = 1
+                prev_line = line
+    return ret_val
+
+if __name__ == '__main__':
+    sys.exit(validate_ordering())


### PR DESCRIPTION
I wrote a pre-commit hook for checking if README.md and github,md are in alphabetical order. Unfortunately, git does not track hooks, so I created a hooks directory in the repo, with a short bash script to deploy the hooks. I also updated the website and github files so they should both now be in alphabetical order.

To test/use the pre-commit hook:

* Run ./deploy_hooks.sh from the top level of the repo. It will symlink pre-commit into .git/hooks/
* Add a name into either README.md or github.md
* Running git commit with no options will run the pre-commit hook and let you know if any of the entries are out of order.

This does not prevent someone from pushing an out of order file, as it can easily be overridden.