### PR TITLE
added Gary-Yau Chan http://garyyauchan.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - Frank Cash http://hackerqueue.io
 - Freddie Vargus http://fjv4.com
 - Gagik Movsisyan http://gagikm.com
+- Gary-Yau Chan http://garyyauchan.com
 - Gautam Mittal http://www.gautam.cc
 - George Lee http://georgel.ee
 - Gibran Garcia http://gibrangarcia.me

--- a/github.md
+++ b/github.md
@@ -241,6 +241,7 @@ Hackathon Hackers' GitHub profiles
 - Frederick Brunn https://github.com/clotifoth
 - Frederik Riedel https://github.com/quappi
 - Gagik Movsisyan https://github.com/gagikm
+- Gary-Yau Chan https://github.com/chany2
 - Garrison https://github.com/smoothtrane
 - Gaurav Ragtah https://github.com/gragtah
 - Gautam Mittal https://github.com/gmittal

--- a/github.md
+++ b/github.md
@@ -241,8 +241,8 @@ Hackathon Hackers' GitHub profiles
 - Frederick Brunn https://github.com/clotifoth
 - Frederik Riedel https://github.com/quappi
 - Gagik Movsisyan https://github.com/gagikm
-- Gary-Yau Chan https://github.com/chany2
 - Garrison https://github.com/smoothtrane
+- Gary-Yau Chan https://github.com/chany2
 - Gaurav Ragtah https://github.com/gragtah
 - Gautam Mittal https://github.com/gmittal
 - Gene Lewis https://github.com/glewis17


### PR DESCRIPTION
Adds @chany2 to the personal-sites repo.

Links added:
- http://garyyauchan.com
- https://github.com/chany2

Notes:
www.TheProductHackers.com

