### PR TITLE
added info for @cbolton97

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - Cheng Peng http://www.chengpeng.ca
 - Chirag Aggarwal http://www.chi6rag.net
 - Chirag Chauhan http://chiragchauhan.com
+- Chris Bolton http://codeandconfusion.com/
 - Chris Lai http://chrislai.info
 - Chris Lee http://collegefill.com
 - Christian Barcenas http://www.cbarcenas.com/

--- a/github.md
+++ b/github.md
@@ -145,6 +145,7 @@ Hackathon Hackers' GitHub profiles
 - Chashmeet Singh https://github.com/chashmeetsingh
 - Cheng Peng https://github.com/chunky123
 - Chirag Chauhan https://github.com/crc442
+- Chris Bolton https://github.com/cbolton97
 - Chris Lai https://github.com/chrislai
 - Chris Lee https://github.com/chrispmlee
 - Christian Barcenas https://github.com/cbarcenas


### PR DESCRIPTION
Adds @cbolton97 to the personal-sites repo.

Links added:
- http://codeandconfusion.com
- https://github.com/cbolton97

