### PR TITLE
Add rootulp

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - Roger Zou http://rogergzou.com
 - Rohan Likhite http://rohanlikhite.com
 - Rohan Yelsangikar http://royels.me
+- Rootul Patel http://rootulp.com/
 - Rosy Gupta http://rosygupta.github.io
 - Ruiqi Mao http://www.ruiqimao.com/
 - Rushi Shah http://www.rshah.io/

--- a/github.md
+++ b/github.md
@@ -611,6 +611,7 @@ Hackathon Hackers' GitHub profiles
 - Rohan Yelsangikar https://github.com/royels
 - Ron Bhatta https://github.com/aranibatta
 - Ronak Patel https://github.com/ronakp
+- Rootul Patel https://github.com/rootulp
 - Ross Semenov https://github.com/rossem
 - Ruiqi Mao https://github.com/ruiqimao
 - Rushi Shah https://github.com/2016rshah


### PR DESCRIPTION
Adds @rootulp to the personal-sites repo.

Links added:
- [rootulp site](http://rootulp.com/)
- [rootulp GitHub](https://github.com/rootulp)

Notes:
N/A