### PR TITLE
Add Brock Whittaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - Brian Chu www.brianchu.com
 - Brian Chuk http://devchuk.github.io/
 - Brijesh Patel https://about.me/brijeshpatel9
+- Brock Whittaker http://www.lavancier.com/
 - Britt Mathis http://bmuk.io
 - Bruno B. Ferrari Faviero http://brunofaviero.com
 - Bryan Garza http://bryangarza.me

--- a/github.md
+++ b/github.md
@@ -133,6 +133,7 @@ Hackathon Hackers' GitHub profiles
 - Brian Lai https://github.com/1337
 - Brijesh Patel https://github.com/Brijeshrpatel9
 - Britt Mathis https://github.com/bmuk
+- Brock Whittaker https://github.com/brockwhittaker
 - Bruno B. Ferrari Faviero https://github.com/bfaviero
 - Bryan Garza https://github.com/bryangarza
 - Burak Içel https://github.com/burakicel


### PR DESCRIPTION
Adds @brockwhittaker to the personal-sites repo.

Links added:
- http://www.lavancier.com/
- https://www.github.com/brockwhittaker

Notes:
— N/A —