### PR TITLE
Added personal website (@ericbachmeier5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - Eli White http://eli-white.com
 - Elissa Shevinsky http://elissashevinsky.com
 - Emily Tran http://emilytran.org
+- Eric Bachmeier http://ericbachmeier5.github.io
 - Eric Lee http://thecreedo.github.io
 - Eric Song http://ericsong.io
 - Eric Zinnikas https://ericz.com


### PR DESCRIPTION
Adds @ericbachmeier5 to the personal-sites repo.

Links added:
- http://ericbachmeier5.github.io
- http://github.com/ericbachmeier5

