### PR TITLE
Added github link (@ericbachmeier5)

### DIFF
--- a/github.md
+++ b/github.md
@@ -234,6 +234,7 @@ Hackathon Hackers' GitHub profiles
 - Elvin Yung https://github.com/elvinyung
 - Emilio Flores https://github.com/EmilioFlores
 - Emily Tran https://github.com/emilytran
+- Eric Bachmeier https://github.com/ericbachmeier5
 - Eric Kamen https://github.com/wchill
 - Eric Lee https://github.com/theCreedo
 - Eric Song https://github.com/ericsong


### PR DESCRIPTION
Adds @ericbachmeier5 to the personal-sites repo.

Links added:
- https://github.com/ericbachmeier5