### PR TITLE
Add Vedant Rathore to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,8 +461,8 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - Vansh Gandhi http://vanshgandhi.com
 - Varun Rajendra Rajamane http://rajamane.io
 - Varun Shenoy http://varunshenoy.github.io/
-- Vetri Selvi Vairamuthu http://vetriselvi.com
 - Vedant Rathore http://vedantrathore.github.io/
+- Vetri Selvi Vairamuthu http://vetriselvi.com
 - Victor Danger Lourng http://victorlourng.com
 - Victor Zhou http://victorzhou.com
 - Vikas Parashar http://vikasparashar.in/


### PR DESCRIPTION
Adds @vedantrathore to the personal-sites repo.

Links added:
- http://vedantrathore.github.io/