### PR TITLE
Added Wilson Ding Personal Site and Github Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - William Cockburn http://syrexide.com
 - William Huang http://www.hellowilliam.com
 - William Woodruff http://woodruffw.us
+- Wilson Ding http://wilsonding.com
 - Xiao He  http://xiaojunhe.com
 - Yask Srivastava http://iyask.me
 - Yasmeen Roumie https://y4smeen.github.io

--- a/github.md
+++ b/github.md
@@ -799,6 +799,7 @@ Hackathon Hackers' GitHub profiles
 - William Jagels https://github.com/wijagels
 - William Wnękowicz https://github.com/flysonic10
 - William Woodruff https://github.com/woodruffw
+- Wilson Ding https://github.com/dingwilson
 - Wilson Mitchell https://github.com/mitchellw
 - Wilson Zhao https://github.com/wilzh40
 - Xiao He  https://github.com/Cigarent


### PR DESCRIPTION
Adds @dingwilson to the personal-sites repo.

Links added:
- http://wilsonding.com
- https://github.com/dingwilson
