### PR TITLE
Add Noga Raviv personal site and github

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - Niraj Pant http://niraj.io
 - Nishanth Shanmugham https://nishanths.github.io
 - Noah Hradek   http://noahhradek.me/
+- Noga Raviv http://nogaraviv.com
 - Oindril Dutta http://odutta.com
 - Ore Aleb http://oreoluwa.me/
 - Palash Chatterjee https://pecey.github.io

--- a/github.md
+++ b/github.md
@@ -566,6 +566,7 @@ Hackathon Hackers' GitHub profiles
 - Nishil Shah https://github.com/nishilshah17
 - Nithi Narayanan https://github.com/nithi001
 - Noah Hradek https://github.com/nhrade/
+- Noga Raviv https://github.com/nogaraviv
 - Numaer Zaker https://github.com/numaer
 - Oindril Dutta https://github.com/duttaoindril
 - Omar Mujahid https://github.com/Omarmjhd


### PR DESCRIPTION
Adds @nogaraviv to the personal-sites repo.

Links added:
- personal-site: http://nogaraviv.com
- github: https://github.com/nogaraviv

Notes:


