### PR TITLE
Add Peter Leng

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - Patricio Córdova http://www.cs.toronto.edu/~patricio
 - Paul Krishnamurthy http://paulkr.com
 - Paweł Szczurko www.pawel.pw
+- Peter Leng http://peterleng.com/
 - Phil Efstathiou http://phil.ws/
 - Prabhakar Gupta http://www.prabhakargupta.com
 - Pradyuman Vig http://www.pradyumanvig.com

--- a/github.md
+++ b/github.md
@@ -589,6 +589,7 @@ Hackathon Hackers' GitHub profiles
 - Pavleen Thukral https://github.com/Thepav
 - Paweł Szczurko https://github.com/ps
 - Payam Ghobadpour https://github.com/payam-g
+- Peter Leng https://github.com/peterl328
 - Phil Efstathiou https://github.com/philefstat
 - Pierce Stegman https://github.com/pwstegman
 - Prabhakar Gupta https://github.com/prabhakar267


### PR DESCRIPTION
Adds @peterl328 to the personal-sites repo.

Links added:
- [http://peterleng.com/](http://peterleng.com/)
- [peterl328](https://github.com/peterl328)
