### PR TITLE
Added aman-roy github profile and amanroy.me website

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - Alexander Mistakidis http://aamistak.me
 - Alston Lin http://alstonlin.io
 - Alvin Deng http://alvindeng.com/
+- Aman Roy http://amanroy.me
 - Amar Prakash Pandey http://amarpandey.me
 - Amrit Singh http://singhamrit.me
 - Anantha Natarajan S http://ananth.co.in

--- a/github.md
+++ b/github.md
@@ -59,6 +59,7 @@ Hackathon Hackers' GitHub profiles
 - Ali Afridi https://github.com/afridi2
 - Alvin Deng https://github.com/alvin319
 - Amanda Sullivan https://github.com/amandasullivan
+- Aman Roy https://github.com/aman-roy
 - Amrit Singh https://github.com/SuperHaker
 - Amyr Haq https://github.com/amyrhaq
 - Anantha Natarajan S https://github.com/sananth12


### PR DESCRIPTION
Adds @aman-roy to the personal-sites repo.

Links added:
- http://amanroy.me
- https://github.com/aman-roy

Notes:
Something you might think is important you can write here.
