### PR TITLE
Update for Grant Park

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - George Lee http://georgel.ee
 - Gibran Garcia http://gibrangarcia.me
 - Gordon Zheng http://gordn.org/
-- Grant Park http://www.grantpark.io
+- Grant Park http://www.grant.ai
 - Grant Timmerman http://grant.cm
 - Greyson Parrelli http://greysonparrelli.com
 - Guilherme Berger http://gberger.me


### PR DESCRIPTION
Links added:
http://grant.ai

Notes:
Got a new domain, so just making sure it's updated here.
