### PR TITLE
@jess843 website and github link

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - Jeremy Meyer http://jeremymeyer.us
 - Jerica Huang http://jericahuang.com
 - Jerrick Davis http://jerrick.us
+- Jess DeJong https://jess843.github.io
 - Jesse Chand http://jessechand.com
 - Jesse Collins http://jtcollins.me
 - Jessica Chang http://jessmchang.com

--- a/github.md
+++ b/github.md
@@ -383,6 +383,7 @@ Hackathon Hackers' GitHub profiles
 - Jeroen Goossens https://github.com/penguinologist
 - Jerrick Davis https://github.com/clevrpwn
 - Jerry Reptak https://github.com/JetFault
+- Jess DeJong https://github.com/jess843
 - Jesse Chand https://github.com/jchand
 - Jesse Collins https://github.com/Jtcollins90
 - Jesse https://github.com/jtcollins90


### PR DESCRIPTION
Adds @jess843 to the personal-sites repo.

Links added:
- https://jess843.github.io
- https://github.com/jess843

Notes:
Something you might think is important you can write here.
