### PR TITLE
Add Nick Wu

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ If you'd like to see GitHub profiles, [click here](github.md).
 - Nelson Liu http://nelsonliu.me
 - Nicholas Brown http://kompulsa.com
 - Nick Roberts https://meadowlab.io
+- Nick Wu https://nickwu241.github.io
 - Nick Zuber https://nickzuber.com
 - Nico Hindering http://nicohinderling.me
 - Nikhita Raghunath https://nikhita.github.io

--- a/github.md
+++ b/github.md
@@ -612,6 +612,7 @@ Hackathon Hackers' GitHub profiles
 - Nick Roberts https://github.com/nickroberts404
 - Nick Sahler https://github.com/nicksahler
 - Nick Sargente https://github.com/primis
+- Nick Wu https://github.com/nickwu241
 - Nick Zuber https://github.com/nickzuber
 - Nicky Semenza https://github.com/nickysemenza
 - Nico Hinderling https://github.com/nicohinderling


### PR DESCRIPTION
Adds @nickwu241 to the personal-sites repo.

Links added:
- your site https://nickwu241.github.io
- your GitHub link https://github.com/nickwu241

Notes:
@timotius02 this is ready for review, thanks!
